### PR TITLE
Fix access to setting variables

### DIFF
--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -8,9 +8,9 @@ from canonicalwebteam.blog.common_view_logic import (
     get_article_context,
 )
 
-tags_id = settings.BLOG_CONFIG.TAGS_ID
-blog_title = settings.BLOG_CONFIG.BLOG_TITLE
-tag_name = settings.BLOG_CONFIG.TAG_NAME
+tags_id = settings.BLOG_CONFIG["TAGS_ID"]
+blog_title = settings.BLOG_CONFIG["BLOG_TITLE"]
+tag_name = settings.BLOG_CONFIG["TAG_NAME"]
 
 
 def index(request):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="1.0.0",
+    version="1.0.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/blog-extension",


### PR DESCRIPTION
# Done
Setting were access with dotnotation. This does not working with the way they are stored on `settings.py`.